### PR TITLE
Show persona role label in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API жёстко переведён на `/api/v1` без редиректов и хвостовых слэшей; старые `/api/*` возвращают `404`.
 - `GET /api/v1/reminders` проксирует ближайшие alarms и помечен устаревшим; используйте `/api/v1/calendar/items/{item_id}/alarms`.
 - API `/api/v1/reminders` переведён в read-only режим, UI редиректит на `/calendar`.
+- В шапке приложения вместо имени пользователя отображается метка его роли.
 
 ### Fixed
 - Исправлены сравнения уровней логирования после перехода на `IntEnum`.

--- a/web/static/js/persona-header.js
+++ b/web/static/js/persona-header.js
@@ -51,7 +51,8 @@ export async function initPersonaHeader() {
 
   const badge = document.createElement('span');
   badge.className = 'persona-badge';
-  badge.textContent = shortName(user);
+  badge.textContent = texts.label || shortName(user);
+  badge.title = shortName(user);
   badge.setAttribute('role', 'button');
   badge.tabIndex = 0;
   badge.setAttribute('aria-haspopup', 'dialog');


### PR DESCRIPTION
## Summary
- show persona role label in header badge instead of user name
- document persona badge change

## Testing
- `source ./venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b429328238832390b125965c3a4685