### PR TITLE
Revamp authorization page layout

### DIFF
--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -325,9 +325,12 @@ async def login(
             flash="reCAPTCHA validation failed",
             status_code=400,
         )
+    exists = None
     try:
         async with WebUserService() as service:
             user = await service.authenticate(username, password)
+            if not user:
+                exists = await service.get_by_username(username)
     except Exception as exc:  # pragma: no cover - defensive
         return render_auth(
             request,
@@ -342,6 +345,14 @@ async def login(
             log_event(request, "login_fail", None, {"username": username})
         except Exception:
             pass
+        if not exists:
+            return render_auth(
+                request,
+                active="register",
+                form_values={"username": username},
+                flash="Invalid credentials",
+                status_code=400,
+            )
         return render_auth(
             request,
             active="login",

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -592,19 +592,15 @@ body.compact .admin-panel {
 /* === /ui2 === */
 /* === auth pages === */
 .auth-page{ background:#262930 linear-gradient(135deg,#2b2f37 0%,#20232a 60%,#1d1f26 100%); min-height:100svh; color:#111827; }
-.auth-header{ text-align:center; padding:22px 0 8px; }
-.auth-header .brand{ color:#f5f5f7; font-weight:800; font-size:22px; text-decoration:none; }
 
 .auth-hero{ min-height:calc(100svh - 60px); display:grid; place-items:center; padding:20px; }
+.auth-brand{ text-align:center; margin-bottom:24px; }
+.auth-brand .brand-name{ font-size:32px; font-weight:800; color:#f5f5f7; }
+.auth-brand .brand-tagline{ margin-top:6px; color:#e5e7eb; }
 .auth-card{
   width:min(720px, 92vw); background:#f1f5f9; border-radius:14px;
   box-shadow:0 16px 50px rgba(0,0,0,.35); padding:0; overflow:hidden;
 }
-
-/* tabs */
-.auth-tabs{ display:flex; gap:24px; padding:16px 20px; background:#e5e7eb; align-items:center; }
-.auth-tabs .tab{ font-weight:700; color:#374151; text-decoration:none; padding:4px 0; border-bottom:2px solid transparent; }
-.auth-tabs .tab.is-active{ color:#111827; border-color:var(--color-accent-purple); }
 
 /* form */
 .auth-form{ padding:20px; background:#f8fafc; border-top:1px solid #e5e7eb; }
@@ -617,6 +613,9 @@ body.compact .admin-panel {
 .control-with-action .toggle-password{ position:absolute; right:8px; top:50%; transform:translateY(-50%); background:none; border:0; cursor:pointer; color:#6b7280; }
 .checkbox{ display:flex; align-items:center; gap:8px; margin:10px 0 18px; }
 .checkbox .right{ margin-left:auto; }
+.login-actions{ display:flex; align-items:center; gap:12px; margin-top:12px; }
+.or-inline{ color:#6b7280; font-size:14px; }
+.login-actions .tg-login{ display:flex; }
 
 .btn{ display:inline-flex; align-items:center; justify-content:center; gap:8px; border:0; border-radius:8px; padding:12px 16px; cursor:pointer; text-decoration:none; font-weight:700; }
 .btn.full{ width:100%; }
@@ -640,6 +639,9 @@ body.compact .admin-panel {
 /* tiny icon for telegram button (reuses sprite if exists) */
 .icon{ width:18px; height:18px; }
 {% comment %} добавь в _icons.html paper-plane при желании {% endcomment %}
+.pwd-field{ position:relative; }
+.pwd-hint{ display:none; position:absolute; top:100%; left:0; width:100%; background:#fffbea; border:1px solid #f3e8a1; border-radius:8px; color:#7c6d1f; padding:8px; margin-top:4px; z-index:10; }
+.pwd-field.show-hint .pwd-hint{ display:block; }
 /* === /auth pages === */
 
 /* === auth (single page) === */

--- a/web/static/js/auth_extra.js
+++ b/web/static/js/auth_extra.js
@@ -42,3 +42,16 @@
   document.querySelectorAll('.form-register input[name="password"], .auth-form input[name="password"][autocomplete="new-password"]').forEach(bind);
 })();
 
+(function(){
+  const field = document.querySelector('.form-register .pwd-field');
+  if (!field) return;
+  const input = field.querySelector('input[name="password"]');
+  const hint = field.querySelector('.pwd-hint');
+  if (!input || !hint) return;
+  function show(){ field.classList.add('show-hint'); }
+  function hide(){ field.classList.remove('show-hint'); }
+  input.addEventListener('focus', show);
+  input.addEventListener('input', show);
+  input.addEventListener('blur', hide);
+})();
+

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -240,39 +240,29 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 })();
 
-// auth: tab switcher on /auth
+// auth: form switcher on /auth
 (function(){
-const tabs = Array.from(document.querySelectorAll('.auth-tabs .tab'));
 const forms = {
-login: document.querySelector('.form-login'),
-register: document.querySelector('.form-register'),
-restore: document.querySelector('.form-restore'),
+  login: document.querySelector('.form-login'),
+  register: document.querySelector('.form-register'),
+  restore: document.querySelector('.form-restore'),
 };
-if (!tabs.length || !forms.login) return;
+if (!forms.login) return;
 
 function activate(name){
-Object.keys(forms).forEach(k=>{
-forms[k]?.classList.toggle('is-hidden', k!==name);
-});
-tabs.forEach(t=>{
-t.classList.toggle('is-active', t.dataset.tab===name);
-t.setAttribute('aria-selected', String(t.dataset.tab===name));
-});
-// для закладки и глубоких ссылок
-if (location.hash !== '#'+name) history.replaceState(null,'','#'+name);
+  Object.keys(forms).forEach(k=>{
+    forms[k]?.classList.toggle('is-hidden', k!==name);
+  });
+  if (location.hash !== '#'+name) history.replaceState(null,'','#'+name);
 }
 
-// клики по табам
 document.addEventListener('click', (e)=>{
-const t = e.target.closest('.auth-tabs .tab');
-const j = e.target.closest('[data-tab-jump]');
-if (t){ e.preventDefault(); activate(t.dataset.tab); }
-if (j){ e.preventDefault(); activate(j.dataset.tabJump); }
+  const j = e.target.closest('[data-tab-jump]');
+  if (j){ e.preventDefault(); activate(j.dataset.tabJump); }
 });
 
-// при загрузке из hash
 const hash = (location.hash||'').replace('#','');
-if (hash && forms[hash]) activate(hash); else activate('login');
+activate(hash && forms[hash] ? hash : 'login');
 })();
 
 // ===== Popover widgets =====

--- a/web/templates/auth.html
+++ b/web/templates/auth.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Авторизация — intData</title>
+  <title>Авторизация — {{ BRAND_NAME }}</title>
   <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
   <script type="module" src="{{ url_for('static', path='js/main.js') }}"></script>
   <script src="{{ url_for('static', path='js/auth_extra.js') }}"></script>
@@ -16,11 +16,11 @@
 <body class="auth-page">
   {% include "_icons.html" %}
 
-  <header class="auth-header">
-    <a class="brand" href="{{ PUBLIC_URL or '/' }}">intData</a>
-  </header>
-
   <main class="auth-hero">
+    <div class="auth-brand">
+      <div class="brand-name">{{ BRAND_NAME }}</div>
+      <div class="brand-tagline">Ваш цифровой второй мозг для профессионального мышления и продуктивной работы</div>
+    </div>
     <div class="auth-card">
       {% if config_warnings and config_warnings|length %}
       <div class="auth-alert" role="status">
@@ -34,12 +34,6 @@
       </div>
       {% endif %}
 
-      <nav class="auth-tabs" role="tablist">
-        <a href="#login"     class="tab {% if active_tab=='login' %}is-active{% endif %}" data-tab="login"     role="tab" aria-selected="{{ 'true' if active_tab=='login' else 'false' }}">Вход</a>
-        <a href="#register"  class="tab {% if active_tab=='register' %}is-active{% endif %}" data-tab="register"  role="tab" aria-selected="{{ 'true' if active_tab=='register' else 'false' }}">Регистрация</a>
-        <a href="#restore"   class="tab {% if active_tab=='restore' %}is-active{% endif %}" data-tab="restore"   role="tab" aria-selected="{{ 'true' if active_tab=='restore' else 'false' }}">Напомнить</a>
-      </nav>
-
       <section class="auth-forms">
         {% if form_errors_json %}
           <script>window.AUTH_ERRORS={{ form_errors_json|safe }};</script>
@@ -49,50 +43,44 @@
         <form action="/login" method="post" class="auth-form form-login{% if active_tab!='login' %} is-hidden{% endif %}" data-validate="login" novalidate>
           {{ csrf_input|safe if csrf_input is defined }}
           <label class="field">
-            <span class="label">Username</span>
             <input class="control" type="text" name="username" autocomplete="username" required placeholder="Ваш логин" value="{{ form_values.username or '' }}">
             <div class="error-text" data-for="username"></div>
           </label>
 
           <label class="field">
-            <span class="label">Пароль</span>
             <div class="control-with-action">
               <input class="control" type="password" name="password" autocomplete="current-password" required placeholder="Введите пароль">
               <button type="button" class="link tiny toggle-password" aria-label="Показать/скрыть пароль">👁</button>
             </div>
+            <a class="link small" href="#restore" data-tab-jump="restore">напомнить</a>
             <div class="error-text" data-for="password"></div>
           </label>
 
           <label class="checkbox">
             <input type="checkbox" name="remember_me" value="1">
             <span>Запомнить меня</span>
-            <a class="link small right" href="#restore" data-tab-jump="restore">напомнить</a>
           </label>
 
           {% if RECAPTCHA_SITE_KEY %}
           <div class="g-recaptcha" data-sitekey="{{ RECAPTCHA_SITE_KEY }}"></div>
           {% endif %}
 
-          <button class="btn primary full" type="submit">Войти</button>
-
-          <div class="or">или</div>
-
           {% if TG_LOGIN_ENABLED %}
-            <div class="tg-login">
-              <script async src="https://telegram.org/js/telegram-widget.js?22"
-                      data-telegram-login="{{ TG_TG_BOT_USERNAME or 'intDataBot' }}"
-                      data-size="large"
-                      data-userpic="false"
-                      data-request-access="write"
-                      data-auth-url="/auth/telegram"
-                      data-lang="ru"></script>
-              <a class="btn telegram full" target="_blank" rel="noopener"
-                 href="https://t.me/{{ (TG_TG_BOT_USERNAME or '@intDataBot')|replace('@','') }}?start=login">
-                <svg class="icon"><use href="#i-paper-plane" /></svg>
-                Открыть {{ TG_TG_BOT_USERNAME or '@intDataBot' }}
-              </a>
-              <div class="muted small">Если виджет не загрузился, нажмите кнопку выше.</div>
+            <div class="login-actions">
+              <div class="tg-login">
+                <script async src="https://telegram.org/js/telegram-widget.js?22"
+                        data-telegram-login="{{ TG_TG_BOT_USERNAME or 'intDataBot' }}"
+                        data-size="large"
+                        data-userpic="false"
+                        data-request-access="write"
+                        data-auth-url="/auth/telegram"
+                        data-lang="ru"></script>
+              </div>
+              <span class="or-inline">или</span>
+              <button class="btn primary" type="submit">Вход</button>
             </div>
+          {% else %}
+            <button class="btn primary full" type="submit">Вход</button>
           {% endif %}
 
           {% if flash %}
@@ -105,19 +93,16 @@
           {{ csrf_input|safe if csrf_input is defined }}
 
           <label class="field">
-            <span class="label">Username</span>
             <input class="control" type="text" name="username" autocomplete="username" required placeholder="Придумайте логин" value="{{ form_values.username or '' }}">
             <div class="error-text" data-for="username"></div>
           </label>
 
           <label class="field">
-            <span class="label">Email</span>
             <input class="control" type="email" name="email" autocomplete="email" required placeholder="Введите Email" value="{{ form_values.email or '' }}">
             <div class="error-text" data-for="email"></div>
           </label>
 
-          <label class="field">
-            <span class="label">Пароль</span>
+          <label class="field pwd-field">
             <div class="control-with-action">
               <input class="control" type="password" name="password" autocomplete="new-password" required placeholder="Создайте пароль">
               <button type="button" class="link tiny toggle-password" aria-label="Показать/скрыть пароль">👁</button>
@@ -128,7 +113,6 @@
           </label>
 
           <label class="field">
-            <span class="label">Повторите пароль</span>
             <input class="control" type="password" name="password2" autocomplete="new-password" required placeholder="Повторите пароль">
             <div class="error-text" data-for="password2"></div>
           </label>
@@ -147,7 +131,6 @@
           <div class="hp-wrap" aria-hidden="true"><input type="text" name="hp_url" tabindex="-1" autocomplete="off"></div>
 
           <label class="field">
-            <span class="label">Email</span>
             <input class="control" type="email" name="email" required placeholder="Введите Email" value="{{ form_values.email or '' }}">
             <div class="error-text" data-for="email"></div>
           </label>


### PR DESCRIPTION
## Summary
- Center brand and tagline on auth screen
- Streamline login, registration, and restore forms
- Toggle password hint popup and form switching scripts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4755da2f8832383c8e84c20ae0296