### PR TITLE
Make calendar interface responsive

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -49,6 +49,16 @@ h1 { font-size: var(--font-size-xl); }
   padding: var(--spacing);
 }
 
+.ui-layout.calendar-layout {
+  max-width: none;
+  width: max-content;
+}
+
+.ui-layout.calendar-layout .card,
+.ui-layout.calendar-layout .ui-table {
+  width: max-content;
+}
+
 button,
 .button {
   background-color: var(--color-accent-turquoise);

--- a/web/templates/calendar.html
+++ b/web/templates/calendar.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Календарь{% endblock %}
 {% block content %}
-<div class="ui-layout">
+<div class="ui-layout calendar-layout">
   <div id="main-content">
     {% if CALENDAR_V2_ENABLED %}
     <div class="ui-notice">новый календарь</div>


### PR DESCRIPTION
## Summary
- Allow calendar layout to expand with its contents
- Apply new responsive layout to calendar page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4797283ec8323b2448972e1f39b3b