### PR TITLE
refine auth page layout and login flow

### DIFF
--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -98,6 +98,16 @@ def render_auth(
     status_code: int | None = None,
     config_warnings: list[dict] | None = None,
 ):
+    origin = f"{request.url.scheme}://{request.url.netloc}".rstrip("/")
+    tg_login_url = None
+    if S.TG_LOGIN_ENABLED and S.TG_BOT_USERNAME:
+        tg_login_url = (
+            "https://oauth.telegram.org/auth"
+            f"?bot={S.TG_BOT_USERNAME}"
+            f"&origin={origin}"
+            "&embed=1&request_access=write"
+            "&return_to=/auth/telegram"
+        )
     return templates.TemplateResponse(
         request,
         "auth.html",
@@ -108,6 +118,7 @@ def render_auth(
             "form_errors_json": json.dumps(form_errors or {}, ensure_ascii=False),
             "flash": flash,
             "config_warnings": config_warnings or _config_diagnostics(request),
+            "tg_login_url": tg_login_url,
         },
         status_code=status_code or 200,
     )

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -603,12 +603,13 @@ body.compact .admin-panel {
 /* === auth pages === */
 .auth-page{ background:#262930 linear-gradient(135deg,#2b2f37 0%,#20232a 60%,#1d1f26 100%); min-height:100svh; color:#111827; }
 
-.auth-hero{ min-height:calc(100svh - 60px); display:grid; place-items:center; padding:20px; }
-.auth-brand{ text-align:center; margin-bottom:24px; }
+.auth-hero{ min-height:100svh; padding:16vh 20px 20px; display:flex; flex-direction:column; align-items:center; }
+.auth-brand{ text-align:center; margin:0 0 24px; }
 .auth-brand .brand-name{ font-size:32px; font-weight:800; color:#f5f5f7; }
 .auth-brand .brand-tagline{ margin-top:6px; color:#e5e7eb; }
 .auth-card{
-  width:min(720px, 92vw); background:#f1f5f9; border-radius:14px;
+  margin-top:8vh;
+  width:min(420px, 92vw); background:#f1f5f9; border-radius:14px;
   box-shadow:0 16px 50px rgba(0,0,0,.35); padding:0; overflow:hidden;
 }
 
@@ -616,16 +617,13 @@ body.compact .admin-panel {
 .auth-form{ padding:20px; background:#f8fafc; border-top:1px solid #e5e7eb; }
 .field{ display:block; margin:12px 0; }
 .label{ display:block; font-size:14px; color:#6b7280; margin-bottom:6px; }
-.control{ width:100%; border:1px solid #d1d5db; border-radius:8px; padding:12px 14px; background:#fff; outline:none; }
+.control{ width:100%; border:1px solid #d1d5db; border-radius:8px; padding:12px 14px; background:#fff; outline:none; box-sizing:border-box; }
 .control:focus{ border-color:#a78bfa; box-shadow:0 0 0 3px rgba(167,139,250,.25); }
 .control-with-action{ position:relative; display:flex; align-items:center; }
 .control-with-action .control{ padding-right:44px; }
 .control-with-action .toggle-password{ position:absolute; right:8px; top:50%; transform:translateY(-50%); background:none; border:0; cursor:pointer; color:#6b7280; }
-.checkbox{ display:flex; align-items:center; gap:8px; margin:10px 0 18px; }
-.checkbox .right{ margin-left:auto; }
-.login-actions{ display:flex; align-items:center; gap:12px; margin-top:12px; }
-.or-inline{ color:#6b7280; font-size:14px; }
-.login-actions .tg-login{ display:flex; }
+.checkbox{ display:flex; align-items:center; gap:8px; margin:0; }
+.login-extra{ display:flex; justify-content:space-between; align-items:center; margin:10px 0 18px; }
 
 .btn{ display:inline-flex; align-items:center; justify-content:center; gap:8px; border:0; border-radius:8px; padding:12px 16px; cursor:pointer; text-decoration:none; font-weight:700; }
 .btn.full{ width:100%; }

--- a/web/templates/auth.html
+++ b/web/templates/auth.html
@@ -40,7 +40,7 @@
         {% endif %}
 
         <!-- LOGIN -->
-        <form action="/login" method="post" class="auth-form form-login{% if active_tab!='login' %} is-hidden{% endif %}" data-validate="login" novalidate>
+        <form action="/auth/login" method="post" class="auth-form form-login{% if active_tab!='login' %} is-hidden{% endif %}" data-validate="login" novalidate>
           {{ csrf_input|safe if csrf_input is defined }}
           <label class="field">
             <input class="control" type="text" name="username" autocomplete="username" required placeholder="Ваш логин" value="{{ form_values.username or '' }}">
@@ -52,36 +52,26 @@
               <input class="control" type="password" name="password" autocomplete="current-password" required placeholder="Введите пароль">
               <button type="button" class="link tiny toggle-password" aria-label="Показать/скрыть пароль">👁</button>
             </div>
-            <a class="link small" href="#restore" data-tab-jump="restore">напомнить</a>
             <div class="error-text" data-for="password"></div>
           </label>
 
-          <label class="checkbox">
-            <input type="checkbox" name="remember_me" value="1">
-            <span>Запомнить меня</span>
-          </label>
+          <div class="login-extra">
+            <label class="checkbox">
+              <input type="checkbox" name="remember_me" value="1">
+              <span>Запомнить меня</span>
+            </label>
+            <a class="link small" href="#restore" data-tab-jump="restore">Напомнить</a>
+          </div>
 
           {% if RECAPTCHA_SITE_KEY %}
           <div class="g-recaptcha" data-sitekey="{{ RECAPTCHA_SITE_KEY }}"></div>
           {% endif %}
 
-          {% if TG_LOGIN_ENABLED %}
-            <div class="login-actions">
-              <div class="tg-login">
-                <script async src="https://telegram.org/js/telegram-widget.js?22"
-                        data-telegram-login="{{ TG_TG_BOT_USERNAME or 'intDataBot' }}"
-                        data-size="large"
-                        data-userpic="false"
-                        data-request-access="write"
-                        data-auth-url="/auth/telegram"
-                        data-lang="ru"></script>
-              </div>
-              <span class="or-inline">или</span>
-              <button class="btn primary" type="submit">Вход</button>
-            </div>
-          {% else %}
-            <button class="btn primary full" type="submit">Вход</button>
+          {% if TG_LOGIN_ENABLED and tg_login_url %}
+            <a class="btn telegram full" href="{{ tg_login_url }}">Войти через Telegram</a>
+            <div class="or">или</div>
           {% endif %}
+          <button class="btn primary full" type="submit">Вход</button>
 
           {% if flash %}
             <div class="auth-alert">{{ flash }}</div>
@@ -89,7 +79,7 @@
         </form>
 
         <!-- REGISTER -->
-        <form action="/register" method="post" class="auth-form form-register{% if active_tab!='register' %} is-hidden{% endif %}" data-validate="register" novalidate>
+        <form action="/auth/register" method="post" class="auth-form form-register{% if active_tab!='register' %} is-hidden{% endif %}" data-validate="register" novalidate>
           {{ csrf_input|safe if csrf_input is defined }}
 
           <label class="field">
@@ -125,10 +115,9 @@
         </form>
 
         <!-- RESTORE -->
-        <form action="/restore" method="post" class="auth-form form-restore{% if active_tab!='restore' %} is-hidden{% endif %}" data-validate="restore" novalidate>
+        <form action="/auth/restore" method="post" class="auth-form form-restore{% if active_tab!='restore' %} is-hidden{% endif %}" data-validate="restore" novalidate>
           {{ csrf_input|safe if csrf_input is defined }}
           <input type="hidden" name="form_ts" value="{{ now_ts }}">
-          <div class="hp-wrap" aria-hidden="true"><input type="text" name="hp_url" tabindex="-1" autocomplete="off"></div>
 
           <label class="field">
             <input class="control" type="email" name="email" required placeholder="Введите Email" value="{{ form_values.email or '' }}">


### PR DESCRIPTION
## Summary
- fix middleware redirect by posting auth forms to `/auth/*`
- unify login layout: remember checkbox & reminder link on one line
- add custom Telegram login button and remove restore honeypot field
- move auth blocks higher and narrow card, inputs use border-box

## Testing
- `python -m venv venv && source venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b47caa2bcc8323a9d427860b79081d