### PR TITLE
Center Telegram login button

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -644,6 +644,8 @@ body.compact .admin-panel {
 /* alerts */
 .auth-alert{ margin-top:12px; padding:10px 12px; background:#fffbea; border:1px solid #f3e8a1; border-radius:8px; color:#7c6d1f; }
 
+.tg-btn-wrapper{ display:flex; justify-content:center; }
+
 /* tiny icon for telegram button (reuses sprite if exists) */
 .icon{ width:18px; height:18px; }
 {% comment %} добавь в _icons.html paper-plane при желании {% endcomment %}

--- a/web/templates/auth.html
+++ b/web/templates/auth.html
@@ -70,12 +70,14 @@
           <button class="btn primary full" type="submit">Вход</button>
           {% if TG_LOGIN_ENABLED and tg_bot_username %}
             <div class="or">или</div>
-            <script async src="https://telegram.org/js/telegram-widget.js?22"
-                    data-telegram-login="{{ tg_bot_username }}"
-                    data-size="large"
-                    data-userpic="false"
-                    data-request-access="write"
-                    data-auth-url="/auth/tg/callback"></script>
+            <div class="tg-btn-wrapper">
+              <script async src="https://telegram.org/js/telegram-widget.js?22"
+                      data-telegram-login="{{ tg_bot_username }}"
+                      data-size="large"
+                      data-userpic="false"
+                      data-request-access="write"
+                      data-auth-url="/auth/tg/callback"></script>
+            </div>
           {% endif %}
 
           {% if flash %}


### PR DESCRIPTION
## Summary
- Wrap Telegram login widget in a centering container
- Add flexbox CSS rule for Telegram login container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b482449a308323ae8f4a772610b078