### PR TITLE
Fix registration redirect after invalid login

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -262,7 +262,11 @@ document.addEventListener('click', (e)=>{
 });
 
 const hash = (location.hash||'').replace('#','');
-activate(hash && forms[hash] ? hash : 'login');
+let defaultTab = 'login';
+for (const [name, form] of Object.entries(forms)){
+  if (form && !form.classList.contains('is-hidden')){ defaultTab = name; break; }
+}
+activate(hash && forms[hash] ? hash : defaultTab);
 })();
 
 // ===== Popover widgets =====


### PR DESCRIPTION
## Summary
- prevent auth page script from overriding server-selected tab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b483fec40c8323b6970add0229ab6c