### PR TITLE
Rearrange auth page to promote Telegram login and add registration button

### DIFF
--- a/web/templates/auth.html
+++ b/web/templates/auth.html
@@ -34,6 +34,18 @@
       </div>
       {% endif %}
 
+      {% if TG_LOGIN_ENABLED and tg_bot_username %}
+        <div class="tg-btn-wrapper">
+          <script async src="https://telegram.org/js/telegram-widget.js?22"
+                  data-telegram-login="{{ tg_bot_username }}"
+                  data-size="large"
+                  data-userpic="false"
+                  data-request-access="write"
+                  data-auth-url="/auth/tg/callback"></script>
+        </div>
+        <div class="or">или</div>
+      {% endif %}
+
       <section class="auth-forms">
         {% if form_errors_json %}
           <script>window.AUTH_ERRORS={{ form_errors_json|safe }};</script>
@@ -68,17 +80,8 @@
           {% endif %}
 
           <button class="btn primary full" type="submit">Вход</button>
-          {% if TG_LOGIN_ENABLED and tg_bot_username %}
-            <div class="or">или</div>
-            <div class="tg-btn-wrapper">
-              <script async src="https://telegram.org/js/telegram-widget.js?22"
-                      data-telegram-login="{{ tg_bot_username }}"
-                      data-size="large"
-                      data-userpic="false"
-                      data-request-access="write"
-                      data-auth-url="/auth/tg/callback"></script>
-            </div>
-          {% endif %}
+          <div class="or">или</div>
+          <button class="btn full" type="button" data-tab-jump="register">Регистрация</button>
 
           {% if flash %}
             <div class="auth-alert">{{ flash }}</div>


### PR DESCRIPTION
## Summary
- show Telegram login above auth forms
- add registration button instead of Telegram button inside login form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b48692b4588323baf7687f79e6f6fc