### PR TITLE
refactor: unify auth flow

### DIFF
--- a/tests/web/test_registration.py
+++ b/tests/web/test_registration.py
@@ -7,16 +7,16 @@ pytest_plugins = ["tests.web.test_auth"]
 @pytest.mark.asyncio
 async def test_register_duplicate_username(client: AsyncClient) -> None:
     resp1 = await client.post(
-        "/auth/register",
+        "/auth/login",
         data={"username": "alice", "password": "secret"},
         follow_redirects=False,
     )
-    assert resp1.status_code in {200, 303}
+    assert resp1.status_code == 303
 
     resp2 = await client.post(
-        "/auth/register",
-        data={"username": "alice", "password": "secret"},
+        "/auth/login",
+        data={"username": "alice", "password": "other"},
         follow_redirects=False,
     )
     assert resp2.status_code == 400
-    assert resp2.json()["detail"] == "username taken"
+    assert "Неверный" in resp2.text

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -632,7 +632,6 @@ body.compact .admin-panel {
 .btn.telegram{ background:#229ED9; color:#fff; }
 .btn.telegram:hover{ filter:brightness(.96); }
 
-.or{ text-align:center; color:#6b7280; font-size:14px; margin:14px 0; }
 
 .social-row{ display:flex; gap:12px; justify-content:center; margin-top:8px; }
 .social{ width:40px; height:40px; border-radius:8px; display:inline-block; }
@@ -644,7 +643,7 @@ body.compact .admin-panel {
 /* alerts */
 .auth-alert{ margin-top:12px; padding:10px 12px; background:#fffbea; border:1px solid #f3e8a1; border-radius:8px; color:#7c6d1f; }
 
-.tg-btn-wrapper{ display:flex; justify-content:center; }
+.tg-btn-wrapper{ display:flex; justify-content:center; width:100%; margin:0 auto 20px; }
 
 /* tiny icon for telegram button (reuses sprite if exists) */
 .icon{ width:18px; height:18px; }

--- a/web/static/js/auth_extra.js
+++ b/web/static/js/auth_extra.js
@@ -4,8 +4,7 @@
   const map = {
     username: 'input[name="username"]',
     email: 'input[name="email"]',
-    password: '.form-login input[name="password"], .form-register input[name="password"]',
-    password2: '.form-register input[name="password2"]'
+    password: '.form-login input[name="password"]'
   };
   Object.entries(window.AUTH_ERRORS).forEach(([name, msg])=>{
     const sel = map[name] || `input[name="${name}"]`;
@@ -17,41 +16,23 @@
   });
 })();
 
+// remind password
 (function(){
-  function scorePwd(v){
-    let s = 0;
-    if (!v) return 0;
-    if (v.length >= 8) s++;
-    if (/[A-Z]/.test(v) && /[a-z]/.test(v)) s++;
-    if (/\d/.test(v)) s++;
-    if (/[^A-Za-z0-9]/.test(v)) s++;
-    if (v.length >= 12) s++;
-    return Math.min(5, s);
-  }
-  function bind(input){
-    const meter = input.closest('.field').querySelector('.pwd-meter');
-    if (!meter) return;
-    const bar = meter.firstElementChild;
-    function upd(){
-      const sc = scorePwd(input.value);
-      meter.dataset.score = String(sc||1);
-      bar.style.width = (sc*20||20) + '%';
+  const btn = document.querySelector('.form-login .remind-btn');
+  if (!btn) return;
+  btn.addEventListener('click', async () => {
+    const username = document.querySelector('.form-login input[name="username"]').value;
+    const body = new URLSearchParams({ username });
+    try {
+      const resp = await fetch('/auth/restore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body
+      });
+      const data = await resp.json();
+      alert(data.detail || 'Операция выполнена');
+    } catch (e) {
+      alert('Ошибка восстановления');
     }
-    input.addEventListener('input', upd); upd();
-  }
-  document.querySelectorAll('.form-register input[name="password"], .auth-form input[name="password"][autocomplete="new-password"]').forEach(bind);
+  });
 })();
-
-(function(){
-  const field = document.querySelector('.form-register .pwd-field');
-  if (!field) return;
-  const input = field.querySelector('input[name="password"]');
-  const hint = field.querySelector('.pwd-hint');
-  if (!input || !hint) return;
-  function show(){ field.classList.add('show-hint'); }
-  function hide(){ field.classList.remove('show-hint'); }
-  input.addEventListener('focus', show);
-  input.addEventListener('input', show);
-  input.addEventListener('blur', hide);
-})();
-

--- a/web/templates/auth.html
+++ b/web/templates/auth.html
@@ -43,7 +43,6 @@
                   data-request-access="write"
                   data-auth-url="/auth/tg/callback"></script>
         </div>
-        <div class="or">или</div>
       {% endif %}
 
       <section class="auth-forms">
@@ -52,7 +51,7 @@
         {% endif %}
 
         <!-- LOGIN -->
-        <form action="/auth/login" method="post" class="auth-form form-login{% if active_tab!='login' %} is-hidden{% endif %}" data-validate="login" novalidate>
+        <form action="/auth/login" method="post" class="auth-form form-login" data-validate="login" novalidate>
           {{ csrf_input|safe if csrf_input is defined }}
           <label class="field">
             <input class="control" type="text" name="username" autocomplete="username" required placeholder="Ваш логин" value="{{ form_values.username or '' }}">
@@ -72,7 +71,7 @@
               <input type="checkbox" name="remember_me" value="1">
               <span>Запомнить меня</span>
             </label>
-            <a class="link small" href="#restore" data-tab-jump="restore">Напомнить</a>
+            <button class="link small remind-btn" type="button">Напомнить</button>
           </div>
 
           {% if RECAPTCHA_SITE_KEY %}
@@ -80,64 +79,10 @@
           {% endif %}
 
           <button class="btn primary full" type="submit">Вход</button>
-          <div class="or">или</div>
-          <button class="btn full" type="button" data-tab-jump="register">Регистрация</button>
 
           {% if flash %}
             <div class="auth-alert">{{ flash }}</div>
           {% endif %}
-        </form>
-
-        <!-- REGISTER -->
-        <form action="/auth/register" method="post" class="auth-form form-register{% if active_tab!='register' %} is-hidden{% endif %}" data-validate="register" novalidate>
-          {{ csrf_input|safe if csrf_input is defined }}
-
-          <label class="field">
-            <input class="control" type="text" name="username" autocomplete="username" required placeholder="Придумайте логин" value="{{ form_values.username or '' }}">
-            <div class="error-text" data-for="username"></div>
-          </label>
-
-          <label class="field">
-            <input class="control" type="email" name="email" autocomplete="email" required placeholder="Введите Email" value="{{ form_values.email or '' }}">
-            <div class="error-text" data-for="email"></div>
-          </label>
-
-          <label class="field pwd-field">
-            <div class="control-with-action">
-              <input class="control" type="password" name="password" autocomplete="new-password" required placeholder="Создайте пароль">
-              <button type="button" class="link tiny toggle-password" aria-label="Показать/скрыть пароль">👁</button>
-            </div>
-            <div class="error-text" data-for="password"></div>
-            <div class="pwd-meter" aria-hidden="true"><i></i></div>
-            <div class="pwd-hint">Минимум 8 символов. Лучше: буквы в разных регистрах, цифры и символы.</div>
-          </label>
-
-          <label class="field">
-            <input class="control" type="password" name="password2" autocomplete="new-password" required placeholder="Повторите пароль">
-            <div class="error-text" data-for="password2"></div>
-          </label>
-
-          {% if RECAPTCHA_SITE_KEY %}
-          <div class="g-recaptcha" data-sitekey="{{ RECAPTCHA_SITE_KEY }}"></div>
-          {% endif %}
-
-          <button class="btn primary full" type="submit">Регистрация</button>
-        </form>
-
-        <!-- RESTORE -->
-        <form action="/auth/restore" method="post" class="auth-form form-restore{% if active_tab!='restore' %} is-hidden{% endif %}" data-validate="restore" novalidate>
-          {{ csrf_input|safe if csrf_input is defined }}
-          <input type="hidden" name="form_ts" value="{{ now_ts }}">
-
-          <label class="field">
-            <input class="control" type="email" name="email" required placeholder="Введите Email" value="{{ form_values.email or '' }}">
-            <div class="error-text" data-for="email"></div>
-          </label>
-
-          <button class="btn primary full" type="submit">Отправить ссылку</button>
-          <div class="or">или</div>
-          <button class="btn full" type="submit" formaction="/auth/magic/request">Войти по магической ссылке</button>
-          <p class="muted small" style="margin-top:10px">Мы пришлём письмо со ссылкой для смены пароля (если такой аккаунт существует).</p>
         </form>
 
       </section>


### PR DESCRIPTION
## Summary
- streamline auth UI into a single login form with Telegram option
- auto-register users on first login and link Telegram accounts
- add inline password reminder and simplify tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b488f6bb48832391e13e12f13e2ef1