### PR TITLE
Fix group handler fallback for display names

### DIFF
--- a/bot/handlers/telegram.py
+++ b/bot/handlers/telegram.py
@@ -278,8 +278,20 @@ async def cmd_group(message: Message):
             return
         members = await user_service.get_group_members(chat.id)
         if members:
-            member_list = "\n".join([m.full_display_name or m.first_name for m in members])
-            await message.answer(f"Участники группы '{chat_title}':\n{member_list}")
+            member_list = "\n".join(
+                [
+                    (
+                        m.bot_settings.get("full_display_name")
+                        if isinstance(m.bot_settings, dict)
+                        and m.bot_settings.get("full_display_name")
+                        else f"{m.first_name} {m.last_name or ''}".strip()
+                    )
+                    for m in members
+                ]
+            )
+            await message.answer(
+                f"Участники группы '{chat_title}':\n{member_list}"
+            )
         else:
             await message.answer("Группа пока пуста.")
 


### PR DESCRIPTION
## Summary
- avoid using missing `full_display_name` attribute when listing group members
- fall back to bot settings or first/last name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49439111483239047531379ca421b