### PR TITLE
fix: unify header brand text styling

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -803,13 +803,11 @@ body:not(.debug) .profile-menu.force-hidden{ display:none !important; }
 
 /* Подправим текст-бренд для читабельности — опционально */
 .app-header .brand-text {
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: .2px;
   line-height: 1;
-  /* цвет под светлую/тёмную темы — подставь свои токены, если есть */
-  color: var(--header-brand-fg, #1f1f1f);
+  color: inherit;
 }
-:root[data-theme="dark"] .app-header .brand-text { color: #fff; }
 
 /* На случай, если где-то был «badge» с рамкой вокруг бренда */
 .app-header .brand-badge,


### PR DESCRIPTION
## Summary
- ensure header brand text matches surrounding style

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49c1e9e388323a32a31796c541ae6