### PR TITLE
Handle asyncpg DDL splitting and reminder migration

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -5,6 +5,7 @@ import logging
 from aiogram.exceptions import TelegramNetworkError
 from core.db import bot, dp
 from core.db.init_app import init_app_once
+from core.db.engine import ENGINE_MODE
 from core.env import env
 from bot.handlers.telegram import user_router, group_router, router
 from bot.handlers.note import router as note_router
@@ -16,6 +17,7 @@ from core.services.telegram_user_service import TelegramUserService
 
 async def main() -> None:
     """Run bot polling with middleware and routers."""
+    logging.getLogger(__name__).info("Bot startup: ENGINE_MODE=%s", ENGINE_MODE)
     await init_app_once(env)
 
     dp.message.middleware(LoggerMiddleware(bot))

--- a/core/db/bootstrap.py
+++ b/core/db/bootstrap.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
 LOG_DIR = Path("logs")
@@ -18,17 +17,133 @@ _file_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(messag
 logger.addHandler(_file_handler)
 
 
-def run_bootstrap_sql(conn: Connection) -> None:
-    """Execute DDL scripts in alphabetical order inside a transaction."""
-    ddl_dir = Path(__file__).resolve().parent / "ddl"
-    paths = sorted(ddl_dir.glob("*.sql"))
+DDL_DIR = Path(__file__).resolve().parent / "ddl"
+
+
+def split_sql(sql: str) -> list[str]:
+    """Split raw SQL text into individual statements.
+
+    Handles quotes, dollar-quoting and comments. Trailing semicolons are
+    stripped. Empty statements and whitespace are ignored.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    i = 0
+    ln = len(sql)
+    in_squote = False
+    in_dquote = False
+    in_line_comment = False
+    in_block_comment = False
+    dollar_tag: str | None = None
+
+    while i < ln:
+        ch = sql[i]
+        nxt = sql[i : i + 2]
+
+        if in_line_comment:
+            buf.append(ch)
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block_comment:
+            buf.append(ch)
+            if nxt == "*/":
+                buf.append("/")
+                i += 2
+                in_block_comment = False
+            else:
+                i += 1
+            continue
+        if dollar_tag is not None:
+            buf.append(ch)
+            if sql.startswith(dollar_tag, i):
+                buf.extend(dollar_tag[1:])  # first char already added
+                i += len(dollar_tag)
+                dollar_tag = None
+            else:
+                i += 1
+            continue
+
+        if ch == "'":
+            buf.append(ch)
+            if in_squote and sql[i + 1 : i + 2] == "'":
+                buf.append("'")
+                i += 2
+                continue
+            in_squote = not in_squote
+            i += 1
+            continue
+
+        if ch == '"':
+            buf.append(ch)
+            if in_dquote and sql[i + 1 : i + 2] == '"':
+                buf.append('"')
+                i += 2
+                continue
+            in_dquote = not in_dquote
+            i += 1
+            continue
+
+        if not in_squote and not in_dquote:
+            if nxt == "--":
+                buf.append(nxt)
+                i += 2
+                in_line_comment = True
+                continue
+            if nxt == "/*":
+                buf.append(nxt)
+                i += 2
+                in_block_comment = True
+                continue
+            if ch == "$":
+                j = i + 1
+                while j < ln and sql[j] != "$":
+                    j += 1
+                if j < ln:
+                    tag = sql[i : j + 1]
+                    buf.append(tag)
+                    dollar_tag = tag
+                    i = j + 1
+                    continue
+            if ch == ";":
+                stmt = "".join(buf).strip()
+                if stmt:
+                    statements.append(stmt)
+                buf.clear()
+                i += 1
+                continue
+
+        buf.append(ch)
+        i += 1
+
+    stmt = "".join(buf).strip()
+    if stmt:
+        statements.append(stmt)
+    return statements
+
+
+def run_bootstrap_sql(conn: Connection) -> dict[str, int]:
+    """Execute DDL scripts sequentially without wrapping them in one txn."""
+
+    paths = sorted(DDL_DIR.glob("*.sql"))
     if not paths:
         logger.info("no ddl files found")
-        return
+        return {"files": 0, "executed": 0, "failed": 0}
+
+    executed = 0
+    failed = 0
     for path in paths:
         sql = path.read_text()
-        try:
-            conn.execute(text(sql))
-            logger.info("applied %s", path.name)
-        except Exception as exc:  # pragma: no cover - log and continue
-            logger.warning("failed %s: %s", path.name, exc)
+        for stmt in split_sql(sql):
+            snippet = stmt.strip().replace("\n", " ")[:200]
+            try:
+                conn.exec_driver_sql(stmt)
+                conn.commit()
+                executed += 1
+            except Exception as exc:  # pragma: no cover - log and continue
+                conn.rollback()
+                failed += 1
+                logger.warning("failed %s: %s; snippet: %s", path.name, exc, snippet)
+
+    return {"files": len(paths), "executed": executed, "failed": failed}

--- a/core/db/ddl/002_reminders_to_alarms.sql
+++ b/core/db/ddl/002_reminders_to_alarms.sql
@@ -1,24 +1,43 @@
 -- Migrate legacy reminders into calendar_items and alarms.
 -- Creates CalendarItem(kind='task') with an Alarm for each reminder.
 
-DO $$
+DO $migrate_reminders$
+DECLARE
+  rn INT;
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name='reminders' AND column_name='item_id'
-    ) THEN
-        WITH personal_areas AS (
-            SELECT id, owner_id FROM areas WHERE type = 'PERSONAL'
-        ),
-        ins_items AS (
-            INSERT INTO calendar_items (kind, title, due_at, area_id, created_at, updated_at)
-            SELECT 'task', '(бывшее напоминание)', r.remind_at, pa.id, now(), now()
-            FROM reminders r
-            JOIN personal_areas pa ON pa.owner_id = r.owner_id
-            RETURNING id, due_at
-        )
-        INSERT INTO alarms (item_id, trigger_at, created_at)
-        SELECT id, due_at, now() FROM ins_items;
-    END IF;
+  -- если таблицы reminders нет — выходим
+  PERFORM 1
+    FROM information_schema.tables
+    WHERE table_name = 'reminders' AND table_schema = 'public';
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- для каждого owner_id в reminders — обеспечим дефолтную area (по названию)
+  INSERT INTO areas (id, owner_id, title, is_active, created_at)
+  SELECT gen_random_uuid(), r.owner_id, 'Нераспределённое', TRUE, now()
+  FROM (SELECT DISTINCT owner_id FROM reminders) r
+  WHERE NOT EXISTS (
+    SELECT 1 FROM areas a
+    WHERE a.owner_id = r.owner_id AND a.title IN ('Нераспределённое','Unassigned','Default','Inbox')
+  );
+
+  -- создаём calendar_items и alarms
+  WITH default_areas AS (
+    SELECT a.owner_id, a.id AS area_id
+    FROM areas a
+    WHERE a.title IN ('Нераспределённое','Unassigned','Default','Inbox')
+  ),
+  ins_items AS (
+    INSERT INTO calendar_items (id, kind, title, area_id, due_at, created_at, updated_at)
+    SELECT gen_random_uuid(), 'task', '(бывшее напоминание)', da.area_id, r.remind_at, now(), now()
+    FROM reminders r
+    JOIN default_areas da ON da.owner_id = r.owner_id
+    RETURNING id, due_at
+  )
+  INSERT INTO alarms (id, item_id, trigger_at, action, payload, enabled, created_at)
+  SELECT gen_random_uuid(), i.id, i.due_at, 'inapp', '{}'::jsonb, TRUE, now()
+  FROM ins_items i;
+
 END
-$$;
+$migrate_reminders$;

--- a/core/db/engine.py
+++ b/core/db/engine.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 from dotenv import load_dotenv
+from sqlalchemy import create_engine as create_sync_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -9,17 +11,29 @@ from base import Base
 
 load_dotenv()
 
-DB_USER = os.getenv("DB_USER")
-DB_PASSWORD = os.getenv("DB_PASSWORD")
-DB_HOST = os.getenv("DB_HOST")
-DB_NAME = os.getenv("DB_NAME")
-DATABASE_URL = f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}"
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    DB_USER = os.getenv("DB_USER")
+    DB_PASSWORD = os.getenv("DB_PASSWORD")
+    DB_HOST = os.getenv("DB_HOST")
+    DB_NAME = os.getenv("DB_NAME")
+    DATABASE_URL = f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}/{DB_NAME}"
 
-engine: AsyncEngine = create_async_engine(DATABASE_URL)
-async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+ENGINE_MODE = "async" if "+asyncpg" in DATABASE_URL else "sync"
+
+if ENGINE_MODE == "async":
+    engine: AsyncEngine | Engine = create_async_engine(DATABASE_URL)
+    async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+else:
+    engine = create_sync_engine(DATABASE_URL, future=True)
+    async_session = None
 
 
 async def init_models() -> None:
     """Create tables for development/testing."""
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    if ENGINE_MODE == "async":
+        async with engine.begin() as conn:  # type: ignore[arg-type]
+            await conn.run_sync(Base.metadata.create_all)
+    else:
+        with engine.begin() as conn:  # type: ignore[attr-defined]
+            Base.metadata.create_all(bind=conn)

--- a/tests/test_bootstrap_split_sql.py
+++ b/tests/test_bootstrap_split_sql.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from core.db.bootstrap import split_sql
+
+
+def test_split_sql_many_statements():
+    sql = Path("core/db/ddl/001_calendar.sql").read_text()
+    stmts = split_sql(sql)
+    assert len(stmts) > 10
+    assert all(not s.strip().endswith(";") for s in stmts)
+
+
+def test_split_sql_do_block():
+    sql = "DO $$ BEGIN RAISE NOTICE 'hi'; END $$;"
+    stmts = split_sql(sql)
+    assert len(stmts) == 1

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -44,7 +44,7 @@ async def test_service_upsert_and_get():
 
 def test_repair_migrates_favorites():
     eng = sa.create_engine("sqlite:///:memory:")
-    with eng.begin() as conn:
+    with eng.connect() as conn:
         conn.execute(sa.text("CREATE TABLE users_web(id INTEGER PRIMARY KEY)")).close()
         conn.execute(
             sa.text(

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -34,6 +34,7 @@ from .routes import (
 )
 from .routes.api_user_settings import router as user_settings_api
 from core.db import engine
+from core.db.engine import ENGINE_MODE
 from core.db.init_app import init_app_once
 from core.env import env
 from core.services.web_user_service import WebUserService
@@ -51,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    logger.info("Lifespan startup: begin")
+    logger.info("Lifespan startup: begin (ENGINE_MODE=%s)", ENGINE_MODE)
     stop_event = None
     task = None
     try:


### PR DESCRIPTION
## Summary
- split DDL files into single statements and execute with per-statement commit/rollback
- refactor init_app_once/repair to use connect()+run_sync without global transaction
- fix reminder migration to avoid missing areas.type and add default area handling
- log ENGINE_MODE at bot/web startup and enhance tests

## Testing
- `source ./venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`
- `python3 main.py` *(fails: AttributeError: 'NoneType' object has no attribute 'lstrip')*

## Links
- [Backlog](docs/BACKLOG.md)
- [Changelog](docs/CHANGELOG.md)

------
https://chatgpt.com/codex/tasks/task_e_68b4cd108ab48323ba4c6860d6e6cf94