### PR TITLE
feat(web): add habits ui

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -20,6 +20,7 @@
   - [E13: Tasks & Time (PARA-first)](#e13-tasks--time-para-first)
   - [E14: Insights & Reports (ревью Areas, фокус-часы)](#e14-insights--reports-ревью-areas-фокус-часы)
   - [E15: User-configurable dashboard (user_settings)](#e15-user-configurable-dashboard-user_settings)
+  - [E16: Habits](#e16-habits)
 - [MR-план](#mr-план)
 - [Definition of Done](#definition-of-done)
 - [Appendix: Notes from merge](#appendix-notes-from-merge)
@@ -261,6 +262,16 @@
 - API `/api/v1/user/settings` позволяет читать и обновлять отдельные ключи.
 - UI страница `/settings` позволяет включать и скрывать виджеты дашборда.
 - На странице `/settings` можно включать или отключать пункты избранного меню с учётом роли пользователя.
+
+### E16: Habits
+**User Stories**
+1. Как пользователь, я отмечаю выполнение привычек и вижу прогресс на странице `/habits`.
+
+**Tasks**
+- P0•S — Страница `/habits`: список, создание, отметка прогресса.
+
+**Acceptance Criteria**
+- Открытие `/habits` отображает привычки пользователя и позволяет отмечать выполнение за сегодня.
 
 ## MR-план
 1. MR-1 Foundations (миграции/модели) — DoD: миграции применяются; приложение поднимается; тесты не падают.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Цвет заметок, закрепление, архив и сортировка drag-and-drop.
 - Эндпоинты `/api/v1/notes/{id}/archive`, `/api/v1/notes/{id}/unarchive`, `/api/v1/notes/reorder`.
 - Привычки требуют `area_id` (проект опционален); `/api/v1/habits` возвращает данные области и проекта, по умолчанию используется «Входящие».
+- Страница `/habits` с простым интерфейсом для управления привычками.
 
 ### Changed
 - Унифицирована работа с паролями через обёртку `core.db.bcrypt` и `WebUserService`.

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -260,7 +260,7 @@ async def api_version_header(request: Request, call_next):
 app.include_router(index.router, include_in_schema=False)
 app.include_router(profile.router, include_in_schema=False)
 app.include_router(settings.router, include_in_schema=False)
-app.include_router(habits.router, include_in_schema=False)
+app.include_router(habits.ui_router, include_in_schema=False)
 app.include_router(tasks.ui_router, include_in_schema=False)
 app.include_router(notes.ui_router, include_in_schema=False)
 app.include_router(areas.ui_router, include_in_schema=False)

--- a/web/routes/habits.py
+++ b/web/routes/habits.py
@@ -1,24 +1,33 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date as dt_date
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
-from core.models import Habit, TgUser
+from core.models import Habit, TgUser, WebUser
 from core.services.nexus_service import HabitService
-from web.dependencies import get_current_tg_user
+from web.dependencies import get_current_tg_user, get_current_web_user
+from ..template_env import templates
 
 
 router = APIRouter(prefix="/habits", tags=["habits"])
+ui_router = APIRouter(
+    prefix="/habits",
+    tags=["habits"],
+    include_in_schema=False,
+)
 
 
 class HabitCreate(BaseModel):
     """Schema for creating a habit."""
 
     name: str
-    frequency: str = Field(..., pattern="^(daily|weekly|monthly)$")
+    frequency: str = Field(
+        ...,
+        pattern="^(daily|weekly|monthly)$",
+    )
     area_id: Optional[int] = None
     project_id: Optional[int] = None
 
@@ -54,27 +63,44 @@ class HabitResponse(BaseModel):
             name=habit.name,
             frequency=habit.frequency,
             progress=progress,
-            area=AreaOut(id=area.id, name=area.name, slug=getattr(area, "slug", None)),
-            project=ProjectOut(id=project.id, name=project.name) if project else None,
+            area=AreaOut(
+                id=area.id,
+                name=area.name,
+                slug=getattr(area, "slug", None),
+            ),
+            project=(
+                ProjectOut(id=project.id, name=project.name)
+                if project
+                else None
+            ),
         )
 
 
 class TogglePayload(BaseModel):
-    date: date
+    date: dt_date
 
 
 @router.get("", response_model=List[HabitResponse])
-async def list_habits(current_user: TgUser | None = Depends(get_current_tg_user)):
+async def list_habits(
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
     if not current_user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     async with HabitService() as service:
-        habits = await service.list_habits(owner_id=current_user.telegram_id)
+        habits = await service.list_habits(
+            owner_id=current_user.telegram_id
+        )
     return [HabitResponse.from_model(h) for h in habits]
 
 
-@router.post("", response_model=HabitResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=HabitResponse,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_habit(
-    payload: HabitCreate, current_user: TgUser | None = Depends(get_current_tg_user)
+    payload: HabitCreate,
+    current_user: TgUser | None = Depends(get_current_tg_user),
 ):
     if not current_user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
@@ -86,7 +112,10 @@ async def create_habit(
             area_id=payload.area_id,
             project_id=payload.project_id,
         )
-        await service.session.refresh(habit, attribute_names=["area", "project"])
+        await service.session.refresh(
+            habit,
+            attribute_names=["area", "project"],
+        )
     return HabitResponse.from_model(habit)
 
 
@@ -105,12 +134,18 @@ async def toggle_habit_progress(
         if habit.owner_id != current_user.telegram_id:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
         updated = await service.toggle_progress(habit_id, payload.date)
-        await service.session.refresh(updated, attribute_names=["area", "project"])
+        await service.session.refresh(
+            updated,
+            attribute_names=["area", "project"],
+        )
     return HabitResponse.from_model(updated)
 
 
 @router.delete("/{habit_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_habit(habit_id: int, current_user: TgUser | None = Depends(get_current_tg_user)):
+async def delete_habit(
+    habit_id: int,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
     if not current_user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     async with HabitService() as service:
@@ -121,6 +156,26 @@ async def delete_habit(habit_id: int, current_user: TgUser | None = Depends(get_
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
         await service.delete(habit_id)
     return None
+
+
+@ui_router.get("")
+async def habits_page(
+    request: Request,
+    current_user: WebUser | None = Depends(get_current_web_user),
+    tg_user: TgUser | None = Depends(get_current_tg_user),
+):
+    habits = []
+    if tg_user:
+        async with HabitService() as svc:
+            habits = await svc.list_habits(owner_id=tg_user.telegram_id)
+    context = {
+        "current_user": current_user,
+        "current_role_name": getattr(current_user, "role", ""),
+        "is_admin": getattr(current_user, "role", "") == "admin",
+        "page_title": "Привычки",
+        "habits": habits,
+    }
+    return templates.TemplateResponse(request, "habits.html", context)
 
 # Alias for centralized API mounting
 api = router

--- a/web/templates/habits.html
+++ b/web/templates/habits.html
@@ -1,0 +1,113 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="page" aria-labelledby="h-habits">
+  <h1 id="h-habits">Привычки</h1>
+
+  <form id="habit-form" class="c-card" style="margin-block:12px">
+    <input name="name" type="text" placeholder="Новая привычка" required>
+    <div class="c-card__bottom">
+      <select name="frequency" aria-label="Частота">
+        <option value="daily">Ежедневно</option>
+        <option value="weekly">Еженедельно</option>
+        <option value="monthly">Ежемесячно</option>
+      </select>
+      <button class="ui-iconbtn" type="submit" data-tooltip="Сохранить" aria-label="Сохранить">
+        <svg><use href="#i-check"/></svg>
+      </button>
+    </div>
+  </form>
+
+  <div id="habitGrid" class="cards-grid" aria-live="polite"></div>
+</section>
+{% endblock %}
+{% block scripts %}
+<script type="module">
+import {confirmDialog} from '/static/js/ui/confirm.js';
+const B = window.API_BASE;
+
+function percent(progress){
+  if(!progress) return 0;
+  const set = new Set(progress);
+  const today = new Date();
+  let done = 0;
+  for(let i=0;i<30;i++){
+    const d = new Date(today);
+    d.setDate(d.getDate()-i);
+    const k = d.toISOString().slice(0,10);
+    if(set.has(k)) done++;
+  }
+  return Math.round(done/30*100);
+}
+
+function cardTemplate(h){
+  const pct = percent(h.progress);
+  const today = new Date().toISOString().slice(0,10);
+  const done = h.progress && h.progress.includes(today);
+  return `<article class="c-card" data-id="${h.id}">
+    <div class="c-card__top">
+      <button class="ui-iconbtn ui-iconbtn--danger js-del" aria-label="Удалить" data-tooltip="Удалить">
+        <svg><use href="#i-trash"/></svg>
+      </button>
+    </div>
+    <div class="c-card__content">
+      <div class="title">${h.name}</div>
+      <div class="habit-progress"><div style="width:${pct}%"></div></div>
+      <div class="muted" style="font-size:12px;">${pct}%</div>
+    </div>
+    <div class="c-card__bottom">
+      <button class="ui-iconbtn js-toggle" aria-label="${done?'Сбросить':'Отметить'}" data-tooltip="${done?'Сбросить':'Отметить'}">
+        <svg><use href="#i-check"/></svg>
+      </button>
+    </div>
+  </article>`;
+}
+
+async function load(){
+  const r = await fetch(`${B}/habits`, {credentials:'include'});
+  const grid = document.getElementById('habitGrid');
+  grid.innerHTML='';
+  if(!r.ok){
+    grid.innerHTML = '<p class="text-muted">Требуется вход и связанный Telegram-аккаунт</p>';
+    return;
+  }
+  const data = await r.json();
+  if(!data.length){
+    grid.innerHTML = '<p class="text-muted">Нет данных</p>';
+    return;
+  }
+  for(const h of data){
+    grid.insertAdjacentHTML('beforeend', cardTemplate(h));
+  }
+}
+
+document.getElementById('habit-form').addEventListener('submit', async (e)=>{
+  e.preventDefault();
+  const fd = new FormData(e.target);
+  const payload = {name: fd.get('name'), frequency: fd.get('frequency')};
+  const r = await fetch(`${B}/habits`, {
+    method:'POST', headers:{'Content-Type':'application/json'}, credentials:'include', body: JSON.stringify(payload)
+  });
+  if(r.ok){ e.target.reset(); load(); }
+});
+
+document.getElementById('habitGrid').addEventListener('click', async (e)=>{
+  const card = e.target.closest('.c-card');
+  if(!card) return;
+  const id = card.dataset.id;
+  if(e.target.closest('.js-toggle')){
+    const today = new Date().toISOString().slice(0,10);
+    await fetch(`${B}/habits/${id}/toggle`, {
+      method:'POST', headers:{'Content-Type':'application/json'}, credentials:'include', body: JSON.stringify({date: today})
+    });
+    load();
+  } else if(e.target.closest('.js-del')){
+    const ok = await confirmDialog({message:'Удалить привычку?'});
+    if(!ok) return;
+    await fetch(`${B}/habits/${id}`, {method:'DELETE', credentials:'include'});
+    load();
+  }
+});
+
+load();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add basic habits page with creation form and progress controls
- include habits UI router in app
- document habits module in backlog and changelog

## Testing
- `python -m venv venv && source ./venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61535c0a88323b81a9cd7b685a9a1