### PR TITLE
fix(web): load page-specific scripts

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -49,5 +49,6 @@
     <script src="{{ url_for('static', path='js/tg_webapp_boot.js') }}" defer></script>
     {% endif %}
     {% include "partials/icons.svg" %}
+    {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include template `scripts` block so page JS (e.g., notes) runs correctly

## Testing
- `python -m venv venv && source venv/bin/activate && pip install --quiet -r requirements.txt && pytest -q`

## References
- [Backlog](docs/BACKLOG.md)
- [Changelog](docs/CHANGELOG.md)

------
https://chatgpt.com/codex/tasks/task_e_68b6dcd4231883238d166668114e1977