### PR TITLE
feat(web): add basic habits API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AGENTS.md aligned with BACKLOG (E1–E16, Habits module, PARA invariants, agent protocol, checklist).
 - Habitica-like module foundations: DDL for habits/habit_logs/dailies/daily_logs/rewards/user_stats.
 - Core services: HabitsService, DailiesService, HabitsCronService, UserStatsService.
-- API: /api/v1/habits*, /api/v1/dailies*, /api/v1/rewards*, /api/v1/habits/stats, /api/v1/habits/cron/run.
+- Public API for habits, dailies, rewards, stats and cron under `/api/v1/*`.
 - /habits page (4 columns), HUD, keyboard shortcuts; Telegram commands (/habit, /daily).
 - Feature flags HABITS_V1_ENABLED, HABITS_RPG_ENABLED in .env.example.
 

--- a/tests/web/test_habits_v1_api.py
+++ b/tests/web/test_habits_v1_api.py
@@ -1,0 +1,152 @@
+import sqlalchemy as sa
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from base import Base
+import core.db as db
+from core.models import TgUser, Area, Project, WebUser
+from core.services.habits import metadata, habits
+
+try:
+    from main import app  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    from main import app  # type: ignore
+
+
+@pytest_asyncio.fixture
+async def client():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:?cache=shared", connect_args={"uri": True}
+    )
+    async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        await conn.run_sync(metadata.create_all)
+    db.engine = engine
+    db.async_session = async_session
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
+    await engine.dispose()
+
+
+async def _seed(owner_id: int, tg_id: int, area_id: int, project_id: int | None = None):
+    async with db.async_session() as session:  # type: ignore
+        async with session.begin():
+            session.add(WebUser(id=owner_id, username="u"))
+            session.add(TgUser(telegram_id=tg_id, first_name="tg"))
+            session.add(
+                Area(id=area_id, owner_id=tg_id, name="A", title="A")
+            )
+            if project_id is not None:
+                session.add(
+                    Project(id=project_id, owner_id=tg_id, area_id=area_id, name="P")
+                )
+
+
+@pytest.mark.asyncio
+async def test_habit_and_reward_flow(client: AsyncClient):
+    await _seed(owner_id=1, tg_id=1, area_id=1, project_id=1)
+    cookies = {"telegram_id": "1"}
+
+    resp = await client.post(
+        "/api/v1/habits",
+        json={
+            "title": "H",
+            "type": "positive",
+            "difficulty": "easy",
+            "project_id": 1,
+        },
+        cookies=cookies,
+    )
+    assert resp.status_code == 201
+    habit_id = resp.json()["id"]
+
+    resp = await client.post(f"/api/v1/habits/{habit_id}/up", cookies=cookies)
+    assert resp.status_code == 200
+
+    resp = await client.post(f"/api/v1/habits/{habit_id}/down", cookies=cookies)
+    assert resp.status_code == 200
+
+    # reward operations
+    resp = await client.post(
+        "/api/v1/rewards",
+        json={"title": "R", "cost_gold": 1, "area_id": 1},
+        cookies=cookies,
+    )
+    assert resp.status_code == 201
+    reward_id = resp.json()["id"]
+
+    resp = await client.post(f"/api/v1/rewards/{reward_id}/buy", cookies=cookies)
+    assert resp.status_code == 200
+    assert "gold_after" in resp.json()
+
+    # insufficient gold
+    resp = await client.post(
+        "/api/v1/rewards",
+        json={"title": "Exp", "cost_gold": 100, "area_id": 1},
+        cookies=cookies,
+    )
+    rid = resp.json()["id"]
+    resp = await client.post(f"/api/v1/rewards/{rid}/buy", cookies=cookies)
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "insufficient_gold"
+
+    # check stats endpoint
+    resp = await client.get("/api/v1/habits/stats", cookies=cookies)
+    assert resp.status_code == 200
+    assert "level" in resp.json()
+
+    # area inherited from project
+    async with db.async_session() as session:  # type: ignore
+        res = await session.execute(
+            sa.select(habits.c.area_id).where(habits.c.id == habit_id)
+        )
+        assert res.scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_daily_and_cron(client: AsyncClient):
+    await _seed(owner_id=2, tg_id=2, area_id=2)
+    cookies = {"telegram_id": "2"}
+
+    resp = await client.post(
+        "/api/v1/dailies",
+        json={
+            "title": "D",
+            "rrule": "FREQ=DAILY",
+            "difficulty": "easy",
+            "area_id": 2,
+        },
+        cookies=cookies,
+    )
+    assert resp.status_code == 201
+    daily_id = resp.json()["id"]
+
+    resp = await client.post(f"/api/v1/dailies/{daily_id}/done", cookies=cookies)
+    assert resp.status_code == 200
+
+    resp = await client.post(f"/api/v1/dailies/{daily_id}/undo", cookies=cookies)
+    assert resp.status_code == 200
+
+    # cron idempotence
+    resp = await client.post("/api/v1/habits/cron/run", cookies=cookies)
+    assert resp.status_code == 200
+    assert resp.json()["ran"] is True
+    resp = await client.post("/api/v1/habits/cron/run", cookies=cookies)
+    assert resp.json()["ran"] is False
+
+
+@pytest.mark.asyncio
+async def test_para_enforcement(client: AsyncClient):
+    await _seed(owner_id=3, tg_id=3, area_id=3)
+    cookies = {"telegram_id": "3"}
+    resp = await client.post(
+        "/api/v1/habits",
+        json={"title": "H", "type": "positive", "difficulty": "easy"},
+        cookies=cookies,
+    )
+    assert resp.status_code == 400
+

--- a/web/routes/__init__.py
+++ b/web/routes/__init__.py
@@ -18,7 +18,6 @@ from .areas import api as areas_api
 from .projects import api as projects_api
 from .resources import api as resources_api
 from .inbox import api as inbox_api
-from .habits import api as habits_api
 from .api_user_settings import router as user_settings_api
 
 # отдельные файлы в web/routes/api/*
@@ -28,6 +27,7 @@ from .api.app_settings import router as app_settings_api
 from .api.auth_webapp import router as auth_webapp_api
 from .api.user_favorites import router as user_favorites_api
 from .api.integrations_google import router as gcal_api
+from .api.habits_v1 import api as habits_v1_api
 
 api_router.include_router(tasks_api)
 api_router.include_router(calendar_api)
@@ -38,7 +38,6 @@ api_router.include_router(areas_api)
 api_router.include_router(projects_api)
 api_router.include_router(resources_api)
 api_router.include_router(inbox_api)
-api_router.include_router(habits_api)
 api_router.include_router(admin_api)
 api_router.include_router(admin_settings_api)
 api_router.include_router(app_settings_api)
@@ -46,3 +45,4 @@ api_router.include_router(auth_webapp_api)
 api_router.include_router(user_favorites_api)
 api_router.include_router(gcal_api)
 api_router.include_router(user_settings_api)
+api_router.include_router(habits_v1_api)

--- a/web/routes/api/habits_v1.py
+++ b/web/routes/api/habits_v1.py
@@ -1,0 +1,247 @@
+"""Public API endpoints for Habitica-like module (habits/dailies/rewards)."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Body
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from core.models import TgUser
+from core.services.habits import (
+    HabitsService,
+    DailiesService,
+    RewardsService,
+    UserStatsService,
+    HabitsCronService,
+)
+from web.dependencies import get_current_tg_user
+
+
+router = APIRouter(tags=["habits"])
+
+
+# ----------------------- Habits -----------------------
+
+
+class HabitIn(BaseModel):
+    title: str
+    type: str
+    difficulty: str
+    note: Optional[str] = None
+    area_id: Optional[int] = None
+    project_id: Optional[int] = None
+
+
+@router.post("/habits", status_code=201)
+async def api_create_habit(
+    payload: HabitIn,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    if payload.area_id is None and payload.project_id is None:
+        raise HTTPException(status_code=400, detail="area_or_project_required")
+    try:
+        async with HabitsService() as svc:
+            hid = await svc.create_habit(
+                owner_id=current_user.telegram_id,
+                title=payload.title,
+                type=payload.type,
+                difficulty=payload.difficulty,
+                area_id=payload.area_id,
+                project_id=payload.project_id,
+                note=payload.note,
+            )
+    except ValueError:
+        raise HTTPException(status_code=400, detail="area_or_project_required")
+    return {"id": hid}
+
+
+@router.post("/habits/{habit_id}/up")
+async def api_habit_up(
+    habit_id: int,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    async with HabitsService() as svc:
+        res = await svc.up(habit_id, owner_id=current_user.telegram_id)
+    if res is None:
+        raise HTTPException(status_code=404)
+    return res
+
+
+@router.post("/habits/{habit_id}/down")
+async def api_habit_down(
+    habit_id: int,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    async with HabitsService() as svc:
+        res = await svc.down(habit_id, owner_id=current_user.telegram_id)
+    if res is None:
+        raise HTTPException(status_code=404)
+    return res
+
+
+@router.get("/habits/stats")
+async def api_stats(current_user: TgUser | None = Depends(get_current_tg_user)):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    async with UserStatsService() as svc:
+        stats = await svc.get_or_create(current_user.telegram_id)
+    stats.pop("owner_id", None)
+    return stats
+
+
+@router.post("/habits/cron/run")
+async def api_cron_run(current_user: TgUser | None = Depends(get_current_tg_user)):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    async with HabitsCronService() as svc:
+        ran = await svc.run(current_user.telegram_id)
+    return {"ran": ran}
+
+
+# ----------------------- Dailies -----------------------
+
+
+class DailyIn(BaseModel):
+    title: str
+    rrule: str
+    difficulty: str
+    note: Optional[str] = None
+    area_id: Optional[int] = None
+    project_id: Optional[int] = None
+
+
+@router.post("/dailies", status_code=201)
+async def api_create_daily(
+    payload: DailyIn,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    if payload.area_id is None and payload.project_id is None:
+        raise HTTPException(status_code=400, detail="area_or_project_required")
+    try:
+        async with DailiesService() as svc:
+            did = await svc.create_daily(
+                owner_id=current_user.telegram_id,
+                title=payload.title,
+                rrule=payload.rrule,
+                difficulty=payload.difficulty,
+                area_id=payload.area_id,
+                project_id=payload.project_id,
+                note=payload.note,
+            )
+    except ValueError:
+        raise HTTPException(status_code=400, detail="area_or_project_required")
+    return {"id": did}
+
+
+class DatePayload(BaseModel):
+    date: Optional[date] = None
+
+
+@router.post("/dailies/{daily_id}/done")
+async def api_daily_done(
+    daily_id: int,
+    payload: DatePayload = Body(default=None),
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    on = payload.date if payload else None
+    async with DailiesService() as svc:
+        ok = await svc.done(daily_id, owner_id=current_user.telegram_id, on=on)
+    if not ok:
+        raise HTTPException(status_code=404)
+    return {"ok": True}
+
+
+@router.post("/dailies/{daily_id}/undo")
+async def api_daily_undo(
+    daily_id: int,
+    payload: DatePayload = Body(default=None),
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    on = payload.date if payload else None
+    async with DailiesService() as svc:
+        ok = await svc.undo(daily_id, owner_id=current_user.telegram_id, on=on)
+    if not ok:
+        raise HTTPException(status_code=404)
+    return {"ok": True}
+
+
+# ----------------------- Rewards -----------------------
+
+
+class RewardIn(BaseModel):
+    title: str
+    cost_gold: int
+    area_id: Optional[int] = None
+    project_id: Optional[int] = None
+
+
+@router.post("/rewards", status_code=201)
+async def api_create_reward(
+    payload: RewardIn,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    if payload.area_id is None and payload.project_id is None:
+        raise HTTPException(status_code=400, detail="area_or_project_required")
+    try:
+        async with RewardsService() as svc:
+            rid = await svc.create(
+                owner_id=current_user.telegram_id,
+                title=payload.title,
+                cost_gold=payload.cost_gold,
+                area_id=payload.area_id,
+                project_id=payload.project_id,
+            )
+    except ValueError:
+        raise HTTPException(status_code=400, detail="area_or_project_required")
+    return {"id": rid}
+
+
+@router.get("/rewards")
+async def api_list_rewards(
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    async with RewardsService() as svc:
+        rewards = await svc.list(current_user.telegram_id)
+    return rewards
+
+
+@router.post("/rewards/{reward_id}/buy")
+async def api_buy_reward(
+    reward_id: int,
+    current_user: TgUser | None = Depends(get_current_tg_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401)
+    try:
+        async with RewardsService() as svc:
+            gold_after = await svc.buy(reward_id, owner_id=current_user.telegram_id)
+    except ValueError:
+        return JSONResponse(
+            status_code=400, content={"error": "insufficient_gold"}
+        )
+    if gold_after is None:
+        raise HTTPException(status_code=404)
+    return {"gold_after": gold_after}
+
+
+# Alias for router include
+api = router
+


### PR DESCRIPTION
## Summary
- expose Habitica-like endpoints for habits, dailies, rewards, stats and cron
- add RewardsService and ensure habit defaults
- cover API with async tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7302900cc8323aad648d8f747044c