### PR TITLE
docs: add frontend modernization epic and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,14 @@
 - Frontend updates must maintain a unified responsive layout so the application remains comfortable on widescreen monitors, square displays, narrow phones, and any other screen sizes.
 - Page titles are rendered in the header via `MODULE_TITLE`; do not duplicate the module name with an extra `<h1>` inside pages.
 
+## Frontend Guidelines
+- Базовый стек: **Next.js 14 + TypeScript + TailwindCSS + React Query**. Исходники располагаются в `web/frontend/`.
+- Компонентный подход на React; данные получаем через React Query и эндпоинты FastAPI `/api/v1/*`.
+- Настроить ESLint, Prettier и Vitest; перед отправкой PR обязательны `npm run lint` и `npm test`.
+- Стандартные команды: `npm run dev`, `npm run build`.
+- Используем app router Next.js в каталоге `app/` (страницы в `web/frontend/app/`).
+- Смотри дорожную карту в [docs/BACKLOG.md#e17-frontend-modernization](docs/BACKLOG.md#e17-frontend-modernization).
+
 ## Testing Guidelines
 - Framework: `pytest` with a running PostgreSQL.
 - Test naming: `tests/test_*.py`; mirror module layout.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -21,6 +21,7 @@
   - [E14: Insights & Reports (ревью Areas, фокус-часы)](#e14-insights--reports-ревью-areas-фокус-часы)
   - [E15: User-configurable dashboard (user_settings)](#e15-user-configurable-dashboard-user_settings)
   - [E16: Habits](#e16-habits)
+  - [E17: Frontend Modernization](#e17-frontend-modernization)
 - [MR-план](#mr-план)
 - [Definition of Done](#definition-of-done)
 - [Appendix: Notes from merge](#appendix-notes-from-merge)
@@ -339,6 +340,23 @@ POST /api/v1/rewards/{id}/buy
 - `/calendar/agenda?include_habits=1` возвращает due-ежедневки; ICS содержит `VTODO` с `RRULE`.
 - `/rewards/{id}/buy` списывает Gold и возвращает баланс.
 - В `/habits` действия мгновенно отражаются в HUD.
+
+### E17: Frontend Modernization
+**User Stories**
+1. Как разработчик, я создаю современный фронтенд на Next.js и TypeScript, чтобы ускорить разработку и унифицировать UI.
+2. Как пользователь, я вижу перенесённые страницы с отзывчивым оформлением и быстрым откликом.
+
+**Tasks**
+- P0•S — Утвердить стек: **Next.js 14 + TypeScript + TailwindCSS + React Query**.
+- P0•M — Инициализировать проект в `web/frontend`, настроить ESLint, Prettier, Vitest и скрипты `npm run dev|build|lint|test`.
+- P1•M — Реализовать базовый layout и API-клиент, работающий с `/api/v1/*`.
+- P1•M — Перенести страницу `/inbox` на новый стек и удалить соответствующие Jinja/JS активы.
+- P1•L — Поэтапно переносить остальные страницы, очищая legacy ресурсы.
+
+**Acceptance Criteria**
+- `npm run build`, `npm test`, `npm run lint` выполняются без ошибок.
+- Мигрированные страницы обслуживаются Next.js и используют React Query для запросов к API.
+- Удалённые legacy файлы фиксируются в `CHANGELOG.md`.
 
 ## MR-план
 1. MR-1 Foundations (миграции/модели) — DoD: миграции применяются; приложение поднимается; тесты не падают.


### PR DESCRIPTION
## Summary
- add E17 Frontend Modernization epic to backlog with tasks and acceptance criteria
- document Next.js + TypeScript + TailwindCSS + React Query as the default frontend stack and required tooling in AGENTS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7683dc7ec8323b45e70d3ad0f6404