### PR TITLE
feat(web): relax habits auth and add tg cta

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,15 @@ Areas — управляемое дерево без ограничения гл
 python -m core.db.migrate && python -m core.db.repair
 ```
 
+## OpenAPI SSoT & export
+
+Снимок API хранится в `api/openapi.json`. Для обновления файла после
+изменений эндпоинтов выполните:
+
+```bash
+python -m web.openapi_export
+```
+
 ### Weekly digests
 
 Включите недельные дайджесты привычек через переменные окружения

--- a/tests/test_habits_auth_web_only.py
+++ b/tests/test_habits_auth_web_only.py
@@ -32,10 +32,14 @@ async def client():
 
 
 @pytest.mark.asyncio
-async def test_page_without_tg(client: AsyncClient):
+async def test_habits_auth_web_only(client: AsyncClient):
     async with db.async_session() as session:  # type: ignore
         async with session.begin():
             session.add(WebUser(id=10, username="u"))
     resp = await client.get("/habits", cookies={"web_user_id": "10"})
     assert resp.status_code == 200
-    assert "Привяжите Telegram" in resp.text
+    assert "Свяжите Telegram для наград" in resp.text
+    resp = await client.post("/api/v1/habits/1/up", cookies={"web_user_id": "10"})
+    assert resp.status_code == 403
+    data = resp.json().get("detail", {})
+    assert data.get("error") == "tg_link_required"

--- a/web/routes/habits.py
+++ b/web/routes/habits.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Request, status
+from fastapi.responses import RedirectResponse
 
 from core.auth.owner import OwnerCtx, get_current_owner
 from core.models import WebUser
@@ -16,7 +17,8 @@ async def habits_page(
     owner: OwnerCtx | None = Depends(get_current_owner),
 ):
     if owner is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        # redirect anonymous users to /auth, keeping status explicit
+        return RedirectResponse("/auth", status_code=status.HTTP_302_FOUND)
     habits = []
     if owner.has_tg:
         async with HabitService() as svc:

--- a/web/templates/habits.html
+++ b/web/templates/habits.html
@@ -4,7 +4,7 @@
   <h1 id="h-habits">Привычки</h1>
   {% if show_tg_cta %}
   <div class="c-card c-card--warning" id="tg-link-banner">
-    Привяжите Telegram для начисления наград/штрафов и бота —
+    Свяжите Telegram для наград —
     <a href="/settings#telegram-linking">Настройки</a>
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- cache OwnerCtx in request.state.owner for reuse
- allow /habits page for web-only sessions with Telegram CTA banner
- document OpenAPI export and cover auth test

## Testing
- `TG_BOT_USERNAME=dummy TG_BOT_TOKEN=abc python -m web.openapi_export`
- `python -m core.db.migrate && python -m core.db.repair` *(fails: connection to server at "127.0.0.1" refused)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76ee37b848323a57769a3955a58a4