### PR TITLE
feat(core/services): add time summary endpoint

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1519,6 +1519,63 @@
         "title": "StatsOut",
         "type": "object"
       },
+      "SummaryItem": {
+        "properties": {
+          "area_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Area Id"
+          },
+          "day": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Day"
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Id"
+          },
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Id"
+          },
+          "total_seconds": {
+            "title": "Total Seconds",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_seconds"
+        ],
+        "title": "SummaryItem",
+        "type": "object"
+      },
       "TaskCreate": {
         "description": "Payload for creating a task.",
         "properties": {
@@ -4750,6 +4807,54 @@
           }
         },
         "summary": "Api:Time Start",
+        "tags": [
+          "time"
+        ]
+      }
+    },
+    "/api/v1/time/summary": {
+      "get": {
+        "description": "Aggregate time entries for the current user.",
+        "operationId": "api_time_summary_api_v1_time_summary_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "group_by",
+            "required": false,
+            "schema": {
+              "default": "day",
+              "title": "Group By",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SummaryItem"
+                  },
+                  "title": "Response Api Time Summary Api V1 Time Summary Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api:Time Summary",
         "tags": [
           "time"
         ]

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -247,7 +247,7 @@
 - [ ] задача требует `project_id` или `area_id`; при указании проекта наследует `area_id`.
 - [ ] напоминания к задаче через `/calendar/items/{id}/alarms`.
 - [ ] флажок календаря `include_tasks/only_scheduled` работает.
-- [ ] `/time/summary` даёт срезы по `project/area/day/user`.
+- [x] `/time/summary` даёт срезы по `project/area/day/user`.
 - [ ] не более одного активного таймера на пользователя.
 
 ### E14: Insights & Reports (ревью Areas, фокус-часы)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Time summary endpoint `/api/v1/time/summary` for aggregating durations by day, project, area or user.
 - comprehensive test suite covering DB idempotency, PARA repair, OpenAPI snapshot parity and core habits/today/tasks/time flows.
 - Epic E17 "Frontend Modernization" в `docs/BACKLOG.md` (Next.js/Vite выбор, TS+Tailwind, перенос страниц, очистка legacy).
 - Машиночитаемая схема БД (`core/db/SCHEMA.*`) и утилита `tools.schema_export` с проверкой в CI.

--- a/tests/test_time_service.py
+++ b/tests/test_time_service.py
@@ -4,7 +4,10 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
 from base import Base
+from datetime import datetime
+
 from core.services.time_service import TimeService
+from core.models import Project, Area
 
 
 @pytest_asyncio.fixture
@@ -30,3 +33,37 @@ async def test_time_entry_start_and_stop(session):
     entries = await service.list_entries(owner_id=1)
     assert len(entries) == 1
     assert entries[0].end_time is not None
+
+
+@pytest.mark.asyncio
+async def test_summary_grouping(session):
+    svc = TimeService(session)
+    # prepare project and area
+    area = Area(owner_id=1, name="A1")
+    session.add(area)
+    await session.flush()
+    project = Project(owner_id=1, area_id=area.id, name="P1")
+    session.add(project)
+    await session.flush()
+    # entry for project on day1 (1h)
+    e1 = await svc.start_timer(owner_id=1, description="Work", project_id=project.id, create_task_if_missing=False)
+    e1.start_time = datetime(2024, 1, 1, 0, 0, 0)
+    e1.end_time = datetime(2024, 1, 1, 1, 0, 0)
+    # entry for same project day2 (0.5h)
+    e2 = await svc.start_timer(owner_id=1, description="Work2", project_id=project.id, create_task_if_missing=False)
+    e2.start_time = datetime(2024, 1, 2, 0, 0, 0)
+    e2.end_time = datetime(2024, 1, 2, 0, 30, 0)
+    # entry for another user (0.25h)
+    e3 = await svc.start_timer(owner_id=2, description="Other", create_task_if_missing=False)
+    e3.start_time = datetime(2024, 1, 1, 0, 0, 0)
+    e3.end_time = datetime(2024, 1, 1, 0, 15, 0)
+    await session.flush()
+
+    by_day = await svc.summary(owner_id=1, group_by="day")
+    assert {"day": "2024-01-01", "total_seconds": 3600} in by_day
+    assert {"day": "2024-01-02", "total_seconds": 1800} in by_day
+    by_project = await svc.summary(owner_id=1, group_by="project")
+    assert by_project == [{"project_id": project.id, "total_seconds": 5400}]
+    by_user = await svc.summary(owner_id=None, group_by="user")
+    assert {"owner_id": 1, "total_seconds": 5400} in by_user
+    assert {"owner_id": 2, "total_seconds": 900} in by_user

--- a/tests/web/test_time_summary_api.py
+++ b/tests/web/test_time_summary_api.py
@@ -1,0 +1,55 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+from datetime import datetime
+
+from base import Base
+import core.db as db
+from core.models import TgUser, TimeEntry
+
+try:
+    from main import app  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    from main import app  # type: ignore
+
+
+@pytest_asyncio.fixture
+async def client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:?cache=shared")
+    async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    db.engine = engine
+    db.async_session = async_session
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac
+    await engine.dispose()
+
+
+async def _create_tg_user(telegram_id: int) -> int:
+    async with db.async_session() as session:  # type: ignore
+        async with session.begin():
+            tg = TgUser(telegram_id=telegram_id, first_name="tg")
+            session.add(tg)
+    return telegram_id
+
+
+async def _add_entry(owner_id: int, start: datetime, end: datetime) -> None:
+    async with db.async_session() as session:  # type: ignore
+        async with session.begin():
+            session.add(TimeEntry(owner_id=owner_id, start_time=start, end_time=end))
+
+
+@pytest.mark.asyncio
+async def test_time_summary_api(client: AsyncClient):
+    user_id = await _create_tg_user(telegram_id=55)
+    await _add_entry(user_id, datetime(2024, 1, 1, 0, 0, 0), datetime(2024, 1, 1, 1, 0, 0))
+    await _add_entry(user_id, datetime(2024, 1, 2, 0, 0, 0), datetime(2024, 1, 2, 0, 30, 0))
+    cookies = {"telegram_id": str(user_id)}
+    resp = await client.get("/api/v1/time/summary?group_by=day", cookies=cookies)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(d["day"] == "2024-01-01" and d["total_seconds"] == 3600 for d in data)
+    assert any(d["day"] == "2024-01-02" and d["total_seconds"] == 1800 for d in data)


### PR DESCRIPTION
## Summary
- add `TimeService.summary` for aggregating time entries
- expose `/api/v1/time/summary` endpoint with day/project/area/user grouping
- document endpoint in BACKLOG and CHANGELOG

## Testing
- `python -m web.openapi_export`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b771fdf10c832380e6f511479e8790