### PR TITLE
fix(habits): allow name-based creation with default area

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -809,7 +809,12 @@
             "title": "Area Id"
           },
           "difficulty": {
+            "default": "easy",
             "title": "Difficulty",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
             "type": "string"
           },
           "note": {
@@ -834,19 +839,14 @@
             ],
             "title": "Project Id"
           },
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
           "type": {
+            "default": "positive",
             "title": "Type",
             "type": "string"
           }
         },
         "required": [
-          "title",
-          "type",
-          "difficulty"
+          "name"
         ],
         "title": "HabitIn",
         "type": "object"
@@ -3247,6 +3247,55 @@
           }
         },
         "summary": "Api Habit Down",
+        "tags": [
+          "Habits"
+        ]
+      }
+    },
+    "/api/v1/habits/{habit_id}/toggle": {
+      "post": {
+        "operationId": "api_habit_toggle_api_v1_habits__habit_id__toggle_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "habit_id",
+            "required": true,
+            "schema": {
+              "title": "Habit Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatePayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Habit Toggle",
         "tags": [
           "Habits"
         ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PARA inheritance for newly created habits/dailies/rewards enforced in services and repair.
 - Habit ORM exposes `.area` and `.project`; `/habits` no longer responds 500 when listing habits.
 - Repair backfills `area_id` from project and warns when both `area_id` and `project_id` are NULL.
+- Habit creation via `/api/v1/habits` no longer fails when area is missing; defaults to Inbox and accepts `name` payload.
 
 ### Security
 - Access control on owner_id for habits/dailies/rewards and logs.

--- a/tests/web/test_habits_v1_api.py
+++ b/tests/web/test_habits_v1_api.py
@@ -154,7 +154,7 @@ async def test_para_enforcement(client: AsyncClient):
         json={"title": "H", "type": "positive", "difficulty": "easy"},
         cookies=cookies,
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 201
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow creating habits without explicit area by defaulting to Inbox
- accept `name` field for `/api/v1/habits` and expose `/habits/{id}/toggle`
- refresh OpenAPI snapshot and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7723830d883239631027eedca2fca