### PR TITLE
feat(web): add sample component test

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -21,7 +21,6 @@
   - [E14: Insights & Reports (ревью Areas, фокус-часы)](#e14-insights--reports-ревью-areas-фокус-часы)
   - [E15: User-configurable dashboard (user_settings)](#e15-user-configurable-dashboard-user_settings)
   - [E16: Habits](#e16-habits)
-  - [E17: Frontend modernization](#e17-frontend-modernization)
   - [E17: Frontend Modernization](#e17-frontend-modernization)
 - [MR-план](#mr-план)
 - [Definition of Done](#definition-of-done)
@@ -344,21 +343,18 @@ POST /api/v1/rewards/{id}/buy
 - В `/habits` действия мгновенно отражаются в HUD.
 
 
-### E17: Frontend modernization
-See [frontend_modernization.md](./frontend_modernization.md).
-
-**Tasks**
-- [ ] E17a: базовая настройка ESLint, Prettier, Vitest и Testing Library в `web/`.
 ### E17: Frontend Modernization
-**User Stories**
-1. Как разработчик, я хочу единый современный фронтенд‑стек, чтобы страницы собирались одним тулчейном.
-2. Как пользователь, я хочу более быстрые и консистентные страницы после миграции.
+See [frontend_modernization.md](./frontend_modernization.md).
 
 **Tasks**
 - P1•M — Исследовать и выбрать стек (Next.js или Vite), задокументировать решение.
 - P1•S — Настроить TypeScript и Tailwind в выбранном фреймворке, подготовить базовый layout.
 - P1•L — Поэтапно переносить страницы на новый стек (начать с `/inbox`), добавлять тесты и запись в `docs/CHANGELOG.md`.
 - P2•S — Удалять legacy‑шаблоны и скрипты после миграции, чистить `web/static` и пути в конфиге Tailwind.
+
+**User Stories**
+1. Как разработчик, я хочу единый современный фронтенд‑стек, чтобы страницы собирались одним тулчейном.
+2. Как пользователь, я хочу более быстрые и консистентные страницы после миграции.
 
 **Acceptance Criteria**
 - В репозитории зафиксировано решение (Next.js или Vite), `npm run dev` стартует без ошибок.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Команда бота `/help` со списком доступных команд.
 - Команда `/group` и проверка членства (декоратор).
 - Web: ESLint, Prettier и Vitest конфигурации.
+- Пример компонента React и тест на Testing Library демонстрируют рабочий стек.
 - Логирование: middleware, пересылка неизвестных сообщений в группу логов, ответы админа, команды `/setloglevel` и `/getloglevel`.
 - Декоратор `role_required` для проверки ролей.
 - Заготовки FSM для обновления контактов и описания групп.

--- a/web/components/Hello.test.tsx
+++ b/web/components/Hello.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import Hello from './Hello';
+
+expect.extend(matchers);
+
+describe('Hello component', () => {
+  it('renders greeting in Russian', () => {
+    render(<Hello name="мир" />);
+    expect(screen.getByText('Привет, мир!')).toBeInTheDocument();
+  });
+});

--- a/web/components/Hello.tsx
+++ b/web/components/Hello.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+
+interface HelloProps {
+  name: string;
+}
+
+export const Hello: FC<HelloProps> = ({ name }) => {
+  return <div>Привет, {name}!</div>;
+};
+
+export default Hello;


### PR DESCRIPTION
## Summary
- add Hello component and Testing Library test to verify frontend stack
- drop completed ESLint/Prettier/Vitest task from E17 backlog
- log example component test in changelog

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Couldn't find any `pages` or `app` directory)*
- `npm run dev`
- `flake8 --exclude=venv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77579464083238d07a955a8b4c832