### PR TITLE
fix(web): default note color when area color absent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -121,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Habit ORM exposes `.area` and `.project`; `/habits` no longer responds 500 when listing habits.
 - Repair backfills `area_id` from project and warns when both `area_id` and `project_id` are NULL.
 - Habit creation via `/api/v1/habits` no longer fails when area is missing; defaults to Inbox and accepts `name` payload.
+- Создание заметки больше не падает при отсутствии цвета у области.
 
 ### Security
 - baseline HTTP headers and optional rate limiting.
@@ -155,4 +156,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - YYYY-MM-DD
 ### Added
 - Инициализация проекта.
-


### PR DESCRIPTION
## Summary
- prevent note creation failure when area lacks color
- record fix in changelog

## Testing
- ⚠️ `pytest -q` (ModuleNotFoundError: No module named 'opentelemetry.instrumentation')
- ⚠️ `pre-commit run --files docs/CHANGELOG.md web/routes/notes.py` (B008: Do not perform function call `Depends` in argument defaults)
- ⚠️ `python -m web.openapi_export` (ModuleNotFoundError: No module named 'opentelemetry.instrumentation')

------
https://chatgpt.com/codex/tasks/task_e_68b8917afcac83239f2d293b451ccd78