### PR TITLE
fix(web): default API base when missing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Кнопка входа через Telegram снова отображается на странице авторизации.
 - reduced test flakiness via deterministic time handling and confirmed cooldown paths mapping to 429.
 - Страница `/inbox` запрашивает заметки у API через `NEXT_PUBLIC_API_BASE`.
+- Фронтенд использует `/api/v1` по умолчанию при отсутствии `window.API_BASE`.
 
 - Автоматическое создание таблицы `app_settings`, исключающей ошибки при её отсутствии.
 - Создание таблицы `user_settings` в repair-скрипте, что предотвращает падения при чтении настроек.

--- a/web/static/js/services/apiBase.js
+++ b/web/static/js/services/apiBase.js
@@ -1,1 +1,1 @@
-export const API_BASE = window.API_BASE;
+export const API_BASE = window.API_BASE || '/api/v1';

--- a/web/static/ts/services/apiBase.ts
+++ b/web/static/ts/services/apiBase.ts
@@ -1,1 +1,1 @@
-export const API_BASE = (window as any).API_BASE as string;
+export const API_BASE = (window as any).API_BASE ?? '/api/v1';


### PR DESCRIPTION
## Summary
- guard API requests from undefined base path by falling back to `/api/v1`
- document frontend default API base

## Testing
- `npm run lint`
- `npm test` *(fails: React is not defined)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.instrumentation')*


------
https://chatgpt.com/codex/tasks/task_e_68b8914c29c48323842f4e6de6657c8a