### PR TITLE
fix: guard Telegram login and load env from ENV_FILE

### DIFF
--- a/core/env.py
+++ b/core/env.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+ENV_FILE = os.getenv("ENV_FILE") or Path(__file__).resolve().parent.parent / ".env"
+load_dotenv(ENV_FILE)
 
 
 @dataclass

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -141,6 +141,7 @@
 
 **Tasks**
 - P0•S — Восстановить кнопку входа через Telegram на странице авторизации.
+- P0•S — Скрывать кнопку входа через Telegram при `TG_LOGIN_ENABLED=0`.
 
 **Acceptance Criteria**
 - `POST /projects/42/notifications` с `chat_id=-1001` привязывает канал.
@@ -182,6 +183,9 @@
 **Acceptance Criteria**
 - `.env.example` содержит `CALENDAR_V2_ENABLED=true`, `HABITS_V1_ENABLED=true`, `HABITS_RPG_ENABLED=true`.
 - CI запускает тесты на синхронизацию, API и уведомления.
+
+**Tasks**
+- P0•S — Загружать переменные окружения из `ENV_FILE` (по умолчанию `${PROJECT_DIR}/.env`).
 
 ### E10: Capture (бот/веб, Inbox)
 **User Stories**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,9 +98,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified OpenAPI SSoT at `/api/openapi.json`; exporter produces `api/openapi.json`.
 - OpenAPI snapshot documents `tg_link_required` and `cooldown` errors.
 - Tailwind config updated for Next.js sources.
+- Загрузка переменных окружения теперь производится из файла, указанного в `ENV_FILE` (по умолчанию `${PROJECT_DIR}/.env`).
 
 ### Fixed
- - Кнопка входа через Telegram снова отображается над формой входа на странице авторизации.
+- Кнопка входа через Telegram снова отображается над формой входа на странице авторизации.
+- Страница авторизации скрывает виджет Telegram при `TG_LOGIN_ENABLED=0`, предотвращая ошибки.
 - reduced test flakiness via deterministic time handling and confirmed cooldown paths mapping to 429.
 - Страница `/inbox` запрашивает заметки у API через `NEXT_PUBLIC_API_BASE`.
 - Фронтенд использует `/api/v1` по умолчанию при отсутствии `window.API_BASE`.

--- a/web/config.py
+++ b/web/config.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from typing import Optional, Literal
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import AnyHttpUrl, ValidationInfo, field_validator
+from pathlib import Path
 import os
 
 
@@ -48,7 +49,8 @@ class EnvSettings(BaseSettings):
 
     # pydantic-settings v2 style configuration
     model_config = SettingsConfigDict(
-        env_file=os.getenv("INTDATA__ENV_FILE", ".env"),
+        env_file=os.getenv("ENV_FILE")
+        or Path(__file__).resolve().parent.parent / ".env",
         case_sensitive=False,
         extra="allow",  # ignore unrelated env vars (e.g., deployment-specific)
     )

--- a/web/templates/auth.html
+++ b/web/templates/auth.html
@@ -35,6 +35,7 @@
       {% endif %}
 
       <section class="auth-forms">
+        {% if TG_LOGIN_ENABLED %}
         <div class="tg-btn-wrapper">
           <script async src="https://telegram.org/js/telegram-widget.js?22"
                   data-telegram-login="{{ tg_bot_username }}"
@@ -43,6 +44,7 @@
                   data-request-access="write"
                   data-auth-url="/auth/tg/callback"></script>
         </div>
+        {% endif %}
         {% if form_errors_json %}
           <script>window.AUTH_ERRORS={{ form_errors_json|safe }};</script>
         {% endif %}


### PR DESCRIPTION
## Summary
- load configuration from ENV_FILE and default project .env
- hide Telegram login button when TG_LOGIN_ENABLED=0 to avoid crashes

## Testing
- `pytest -q` *(fails: No module named 'opentelemetry.instrumentation')*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e22d2608323966b2c7038d56841