### PR TITLE
chore(env): log env file origin

### DIFF
--- a/core/env.py
+++ b/core/env.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -7,8 +8,23 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 
-ENV_FILE = os.getenv("ENV_FILE") or Path(__file__).resolve().parent.parent / ".env"
-load_dotenv(ENV_FILE)
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ENV_FILE = Path(os.getenv("ENV_FILE") or PROJECT_ROOT / ".env")
+dotenv_loaded = load_dotenv(ENV_FILE)
+
+if dotenv_loaded:
+    if ENV_FILE.resolve().parent == PROJECT_ROOT:
+        logger.info("Loaded .env from project root: %s", ENV_FILE)
+    else:
+        logger.warning(
+            "Loaded .env from %s (expected root %s)",
+            ENV_FILE.resolve(),
+            PROJECT_ROOT,
+        )
+else:
+    logger.warning("Env file %s not found", ENV_FILE)
 
 
 @dataclass

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAPI snapshot documents `tg_link_required` and `cooldown` errors.
 - Tailwind config updated for Next.js sources.
 - Загрузка переменных окружения теперь производится из файла, указанного в `ENV_FILE` (по умолчанию `${PROJECT_DIR}/.env`).
+- Логируется путь загруженного `.env` и выводится предупреждение, если файл находится вне корня проекта.
 
 ### Fixed
 - Кнопка входа через Telegram снова отображается над формой входа на странице авторизации.

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -1,0 +1,5 @@
+from core.env import ENV_FILE, PROJECT_ROOT
+
+
+def test_env_file_in_project_root():
+    assert ENV_FILE.resolve().parent == PROJECT_ROOT


### PR DESCRIPTION
## Summary
- log env file path at startup and warn when not in project root
- add test ensuring ENV_FILE resolves to project root
- document env logging in changelog

Relates to [E1](docs/BACKLOG.md#e1-para-first-%D0%B4%D0%BE%D0%BC%D0%B5%D0%BD%D0%BD%D0%B0%D1%8F-%D0%BC%D0%BE%D0%B4%D0%B5%D0%BB%D1%8C-areasprojectscalendaritemalarm).

## Testing
- `flake8 core/env.py tests/test_env_file.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.instrumentation')*

------
https://chatgpt.com/codex/tasks/task_e_68bcaa02836c8323ab0a377c56455f80